### PR TITLE
fix: Remove favicon link from HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="./styles.css" />
   <title>Alberto Marín</title>
-  <link rel="icon" type="image/png" href="assets/images/githubLogo.jpg" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous" />
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js"


### PR DESCRIPTION
As per your request, this commit removes the <link rel="icon" ...> tag from index.html to prevent a favicon from being displayed.